### PR TITLE
Always produce arrays in output yaml

### DIFF
--- a/src/__tests__/workflows/output.yml
+++ b/src/__tests__/workflows/output.yml
@@ -32,7 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: '11.7'
+        xcode:
+          - '11.7'
         platform: ["iOS", "tvOS"]
 
     steps:
@@ -47,7 +48,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: '12.1'
+        xcode:
+          - '12.1'
         platform: ["iOS", "tvOS"]
 
     steps:
@@ -62,7 +64,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: '12.3'
+        xcode:
+          - '12.3'
 
     steps:
       - uses: actions/checkout@v2
@@ -76,7 +79,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: '12.2'
+        xcode:
+          - '12.2'
 
     steps:
       - uses: actions/checkout@v2

--- a/src/applyXcodeVersion.py
+++ b/src/applyXcodeVersion.py
@@ -13,10 +13,7 @@ def getFromDict(dataDict, mapList):
 
 
 def setInDict(dataDict, mapList, value):
-    if len(value) == 1:
-        getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value[0]
-    else:
-        getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value
+    getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value
 
 
 parser = argparse.ArgumentParser(description="Apply Xcode version to YAML file")


### PR DESCRIPTION
Values in `matrix` must be arrays, so this would cause issues when the workflow runs